### PR TITLE
feat: AU-1892: Tunnistamo AD roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Helsinki profiili integration
 
-lisätään allulle viestiä...
-
 This module integrates user data in Helsinki profiili to Drupal. Required Tunnistamo openid authentication.
 
 Userdata is queried from graphql endpoint in Tunnistamo. Userdata is saved for request in class. Nothing is saved locally.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Helsinki profiili integration
 
+lisätään allulle viestiä...
+
 This module integrates user data in Helsinki profiili to Drupal. Required Tunnistamo openid authentication.
 
 Userdata is queried from graphql endpoint in Tunnistamo. Userdata is saved for request in class. Nothing is saved locally.

--- a/helfi_helsinki_profiili.module
+++ b/helfi_helsinki_profiili.module
@@ -86,21 +86,6 @@ function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $ac
         fn(string $rid) => $account->addRole($rid),
         $rolesConfig["admin_user_roles"]
       );
-      if (isset($context["user_data"]["ad_groups"]) && !empty($context["user_data"]["ad_groups"])) {
-        // Get ad groups from config.
-        $adRoleMappings = $config->get('ad_role_mappings');
-        // Add mapped roles for users' ad groups.
-        array_map(
-          function ($adGroup) use ($account, $adRoleMappings) {
-            array_map(
-              fn(string $rid) => $account->addRole($rid),
-              $adRoleMappings[$adGroup] ?? []
-            );
-          },
-          $context["user_data"]["ad_groups"]
-        );
-      }
-
       // Add roles based on the email.
       if ($context['user_data']['email'] && $emailRoleMappings[$context['user_data']['email']]) {
         $customRoles = $emailRoleMappings[$context['user_data']['email']];


### PR DESCRIPTION
# [AU-1892](https://helsinkisolutionoffice.atlassian.net/browse/AU-1892)

## What was done

This pull request removes the AD role <-> Drupal role mapping from the `helfi_helsinki_profiili_openid_connect_post_authorize` hook. This change has been implemented because the mapping should be done within a *.settings.php file, which is suggested by the `helfi_tunnistamo` modules .README file. The mapping has been re-implemented [here](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1395).

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-1892-tunnistamo-ad-roles`
* `make fresh`
* `make drush-cr`

## How to test
- Review the code and check that only the AD role <-> Drupal mapping has been removed from the hook.
- The pull request should be tested [here](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1395).

[AU-1892]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ